### PR TITLE
Fixed PhysFS-cpp fbuf overflow

### DIFF
--- a/engine/inspector/private/inspector_module.cpp
+++ b/engine/inspector/private/inspector_module.cpp
@@ -327,12 +327,11 @@ void DumpVMAStats(Engine& engine)
     vmaBuildStatsString(engine.GetModule<RendererModule>().GetRenderer()->GetContext()->GetVulkanContext()->MemoryAllocator(), &statsJson, true);
 
     const char* outputFilePath = "vma_stats.json";
-    std::ofstream file { outputFilePath };
-    if (file.is_open())
+    auto stream = fileIO::OpenWriteStream(outputFilePath);
+    if (stream)
     {
+        auto& file = stream.value();
         file << statsJson;
-
-        file.close();
     }
     else
     {

--- a/engine/utility/private/physfs.cpp
+++ b/engine/utility/private/physfs.cpp
@@ -72,25 +72,6 @@ private:
 
     int_type overflow(int_type c = traits_type::eof())
     {
-#if 0
-        if (pptr() == pbase() && c == traits_type::eof())
-        {
-            return 0; // no-op
-        }
-        if (PHYSFS_writeBytes(file, pbase(), pptr() - pbase()) < 1)
-        {
-            return traits_type::eof();
-        }
-        if (c != traits_type::eof())
-        {
-            if (PHYSFS_writeBytes(file, &c, 1) < 1)
-            {
-                return traits_type::eof();
-            }
-        }
-
-        return 0;
-#endif
         if(pptr() != pbase())
         {
             auto n = pptr() - pbase();

--- a/engine/utility/private/physfs.cpp
+++ b/engine/utility/private/physfs.cpp
@@ -72,6 +72,7 @@ private:
 
     int_type overflow(int_type c = traits_type::eof())
     {
+#if 0
         if (pptr() == pbase() && c == traits_type::eof())
         {
             return 0; // no-op
@@ -89,11 +90,30 @@ private:
         }
 
         return 0;
+#endif
+        if(pptr() != pbase())
+        {
+            auto n = pptr() - pbase();
+            if(PHYSFS_writeBytes(file, pbase(), n) < n)
+            {
+                return traits_type::eof();
+            }
+        }
+
+        setp(pbase(), epptr());
+
+        if(!traits_type::eq_int_type(c, traits_type::eof()))
+        {
+            *pptr() = traits_type::to_char_type(c);
+            pbump(1);
+        }
+
+        return traits_type::not_eof(c);
     }
 
     int sync()
     {
-        return overflow();
+        return overflow() == traits_type::eof() ? -1 : 0;
     }
 
     char* buffer;


### PR DESCRIPTION
### Description

PhysFS-cpp libary's fbuf overflow function was not correctly putting the file pointer in the right position on overflow(). Basically this meant that on overflow the buffer kept writing the same section to file until the end of the input was reached, resulting in files that were growing larger in size

Also changed the DumpVMAStats to use the fileIO API

### Issues

closes: #65 

### Test criteria

- [ ] Test using the Save Settings and Dump VMA stats button
- [ ] Files should not be abnormally large, also re-running the project should not crash the application on load
